### PR TITLE
Add support for ASB emulator

### DIFF
--- a/PurpleExplorer/Helpers/BaseHelper.cs
+++ b/PurpleExplorer/Helpers/BaseHelper.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Identity;
+﻿using System;
+using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using PurpleExplorer.Models;
@@ -11,10 +12,12 @@ public abstract class BaseHelper
 
     protected ServiceBusAdministrationClient GetManagementClient(ServiceBusConnectionString connectionString)
     {
-        if (connectionString.UseManagedIdentity)
-            return new ServiceBusAdministrationClient(connectionString.ConnectionString, new DefaultAzureCredential());
+        var managementConnectionString = GetManagementConnectionString(connectionString.ConnectionString);
 
-        return new ServiceBusAdministrationClient(connectionString.ConnectionString);
+        if (connectionString.UseManagedIdentity)
+            return new ServiceBusAdministrationClient(managementConnectionString, new DefaultAzureCredential());
+
+        return new ServiceBusAdministrationClient(managementConnectionString);
     }
 
     protected ServiceBusReceiver GetMessageReceiver(
@@ -45,9 +48,67 @@ public abstract class BaseHelper
 
     protected ServiceBusClient GetServiceBusClient(ServiceBusConnectionString connectionString)
     {
-        if (connectionString.UseManagedIdentity)
-            return new ServiceBusClient(connectionString.ConnectionString, new DefaultAzureCredential());
+        var messagingConnectionString = GetMessagingConnectionString(connectionString.ConnectionString);
 
-        return new ServiceBusClient(connectionString.ConnectionString);
+        if (connectionString.UseManagedIdentity)
+            return new ServiceBusClient(messagingConnectionString, new DefaultAzureCredential());
+
+        return new ServiceBusClient(messagingConnectionString);
+    }
+
+    private string GetManagementConnectionString(string? connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+            return string.Empty;
+
+        // If emulator mode, ensure port 5300 for management operations
+        if (connectionString.Contains("UseDevelopmentEmulator=true", StringComparison.OrdinalIgnoreCase))
+        {
+            return EnsurePort(connectionString, "5300");
+        }
+        return connectionString;
+    }
+
+    private string GetMessagingConnectionString(string? connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+            return string.Empty;
+
+        // If emulator mode, ensure port 5672 for messaging operations
+        if (connectionString.Contains("UseDevelopmentEmulator=true", StringComparison.OrdinalIgnoreCase))
+        {
+            return EnsurePort(connectionString, "5672");
+        }
+        return connectionString;
+    }
+
+    private string EnsurePort(string connectionString, string port)
+    {
+        // Parse the connection string to modify the Endpoint
+        var parts = connectionString.Split(';');
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (parts[i].StartsWith("Endpoint=", StringComparison.OrdinalIgnoreCase))
+            {
+                var endpoint = parts[i].Substring("Endpoint=".Length);
+
+                // Remove any existing port
+                if (endpoint.Contains(":"))
+                {
+                    var uriParts = endpoint.Split(':');
+                    if (uriParts.Length >= 2)
+                    {
+                        // Reconstruct without port: sb://hostname
+                        endpoint = $"{uriParts[0]}:{uriParts[1]}";
+                    }
+                }
+
+                // Add the specified port
+                parts[i] = $"Endpoint={endpoint}:{port}";
+                break;
+            }
+        }
+
+        return string.Join(";", parts);
     }
 }

--- a/PurpleExplorer/appstate.json
+++ b/PurpleExplorer/appstate.json
@@ -7,6 +7,11 @@
         "$type": "PurpleExplorer.Models.ServiceBusConnectionString, PurpleExplorer",
         "UseManagedIdentity": false,
         "ConnectionString": "Endpoint=sb://your-service-bus.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=YourSharedAccessKey="
+      },
+      {
+        "$type": "PurpleExplorer.Models.ServiceBusConnectionString, PurpleExplorer",
+        "UseManagedIdentity": false,
+        "ConnectionString": "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
       }
     ]
   },
@@ -19,6 +24,7 @@
     "QueueListFetchCount": 100,
     "QueueMessageFetchCount": 100,
     "TopicListFetchCount": 100,
-    "TopicMessageFetchCount": 100
+    "TopicMessageFetchCount": 100,
+    "TopicListWidth": 400.0
   }
 }

--- a/README.md
+++ b/README.md
@@ -51,5 +51,6 @@ Since forking from the original project, the following significant updates have 
 * (editorconfig, better naming).
 * Added key bindings and buttons for closing windows.
 * Fixed various bugs including null reference exceptions, timeout issues, and app state handling.
+* Added support for [ASB emulator](https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator?tabs=docker-linux-container) with dual ports setup when `UseDevelopmentEmulator=true` flag is set.
 
 For a full list of changes, see the git commit history.


### PR DESCRIPTION
## Description

The current state of the PurpleExplorer project seems to primarily target real service bus instances, as shown with `your-service-bus.servicebus.windows.net` in the `appstate.json` preset. However, this tool can also be very useful for local development with access to the dockerized [ASB emulator](https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator?tabs=docker-linux-container) setup recommended by Microsoft. 

### Current Problem

The Azure Service Bus emulator uses two separate ports for different types of operations:

- Port 5672: AMQP messaging operations (sending/receiving messages)
- Port 5300: Management/administration operations (listing topics, queues, subscriptions, etc.)

This differs from production Azure Service Bus, which handles both operation types through the same endpoint.

So if you try to connect to the emulator locally with the current state of PurpleExplorer, it will detect the topic and queues well, but trying to view what is on a queue triggers an infinite loading screen.

### Proposed Fix

This PR resolves this problem with some added flexibility in the `BaseHelper.cs` class, where it now:

1. Detects emulator mode by checking for `UseDevelopmentEmulator=true` in the connection string
2. Routes operations to the correct port:
- GetManagementConnectionString() → ensures port 5300 for ServiceBusAdministrationClient (used for browsing queues, topics, subscriptions)
- GetMessagingConnectionString() → ensures port 5672 for ServiceBusClient (used for message send/receive operations)
3. Modifies the endpoint dynamically using the EnsurePort() method, which parses the connection string and rebuilds it with the appropriate port
